### PR TITLE
Add auto release

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,0 +1,31 @@
+name: Python release
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN_DIST }}
+
+jobs:
+  python_release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install setuptools wheel
+    - run: python setup.py sdist bdist_wheel
+
+    - run: |
+        pip install twine
+    - name: Upload to PyPi
+      run: |
+          twine upload dist/* -u __token__ -p "$PYPI_TOKEN"


### PR DESCRIPTION
The behavior with this PR is that once you push a Git tag with `v*` (usually `v1.0.8` for example), which should ideally point to the commit that updates this line https://github.com/huggingface/huggingface_sb3/blob/main/setup.py#L10 (you can push the tag after the commit), it will automatically make a pypi release. 

The only requirement is adding your secret (`PYPI_TOKEN_DIST`) to the repo settings