### PR TITLE
Environment name normalization and explicit naming schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,23 @@ If you use **Colab or a Virtual/Screenless Machine**, you can check Case 3 and C
 ```python
 import gym
 
-from huggingface_sb3 import load_from_hub
+from huggingface_sb3 import load_from_hub, RepoId, ModelName, EnvironmentName
 from stable_baselines3 import PPO
 from stable_baselines3.common.evaluation import evaluate_policy
 
 # Retrieve the model from the hub
 ## repo_id = id of the model repository from the Hugging Face Hub (repo_id = {organization}/{repo_name})
 ## filename = name of the model zip file from the repository
+environment_name = EnvironmentName("CartPole-v1")
+model_name = ModelName("ppo", environment_name)
 checkpoint = load_from_hub(
-    repo_id="sb3/demo-hf-CartPole-v1",
-    filename="ppo-CartPole-v1.zip",
+    repo_id=RepoId("sb3", model_name),
+    filename=model_name.filename,
 )
 model = PPO.load(checkpoint)
 
 # Evaluate the agent and watch it
-eval_env = gym.make("CartPole-v1")
+eval_env = gym.make(environment_name.gym_id)
 mean_reward, std_reward = evaluate_policy(
     model, eval_env, render=False, n_eval_episodes=5, deterministic=True, warn=False
 )
@@ -61,14 +63,16 @@ import gym
 
 from stable_baselines3 import PPO
 from stable_baselines3.common.env_util import make_vec_env
-from huggingface_sb3 import package_to_hub
+from huggingface_sb3 import package_to_hub, EnvironmentName, ModelName, RepoId
+
+env_name = EnvironmentName('LunarLander-v2')
+model_name = ModelName("ppo", env_name)
 
 # Create the environment
-env_id = 'LunarLander-v2'
-env = make_vec_env(env_id, n_envs=1)
+env = make_vec_env(env_name.env_id, n_envs=1)
 
 # Create the evaluation env
-eval_env = make_vec_env(env_id, n_envs=1)
+eval_env = make_vec_env(env_name.env_id, n_envs=1)
 
 # Instantiate the agent
 model = PPO('MlpPolicy', env, verbose=1)
@@ -78,11 +82,11 @@ model.learn(total_timesteps=int(5000))
 
 # This method save, evaluate, generate a model card and record a replay video of your agent before pushing the repo to the hub
 package_to_hub(model=model, 
-               model_name="ppo-LunarLander-v2",
+               model_name=model_name,
                model_architecture="PPO",
-               env_id=env_id,
+               env_id=env_name.env_id,
                eval_env=eval_env,
-               repo_id="ThomasSimonini/ppo-LunarLander-v2",
+               repo_id=RepoId("ThomasSimonini", model_name),
                commit_message="Test commit")
 ```
 
@@ -95,11 +99,13 @@ import gym
 
 from stable_baselines3 import PPO
 from stable_baselines3.common.env_util import make_vec_env
-from huggingface_sb3 import push_to_hub
+from huggingface_sb3 import push_to_hub, EnvironmentName, ModelName, RepoId
+
+env_name = EnvironmentName('LunarLander-v2')
+model_name = ModelName("ppo", env_name)
 
 # Create the environment
-env_id = 'LunarLander-v2'
-env = make_vec_env(env_id, n_envs=1)
+env = make_vec_env(env_name.gym_id, n_envs=1)
 
 # Instantiate the agent
 model = PPO('MlpPolicy', env, verbose=1)
@@ -108,15 +114,15 @@ model = PPO('MlpPolicy', env, verbose=1)
 model.learn(total_timesteps=10_000)
 
 # Save the model
-model.save("ppo-LunarLander-v2")
+model.save(model_name)
 
 # Push this saved model .zip file to the hf repo
 # If this repo does not exists it will be created
 ## repo_id = id of the model repository from the Hugging Face Hub (repo_id = {organization}/{repo_name})
 ## filename: the name of the file == "name" inside model.save("ppo-LunarLander-v2")
 push_to_hub(
-    repo_id="ThomasSimonini/ppo-LunarLander-v2",
-    filename="ppo-LunarLander-v2.zip",
+    repo_id=RepoId("ThomasSimonini", model_name),
+    filename=model_name.filename,
     commit_message="Added LunarLander-v2 model trained with PPO",
 )
 ```

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ We wrote a tutorial on how to use 🤗 Hub and Stable-Baselines3 [here](https://
 If you use **Colab or a Virtual/Screenless Machine**, you can check Case 3 and Case 4.
 
 ### Case 1: I want to download a model from the Hub
+
 ```python
 import gym
 
-from huggingface_sb3 import load_from_hub, RepoId, ModelName, EnvironmentName
+from huggingface_sb3 import load_from_hub, ModelRepoId, ModelName, EnvironmentName
 from stable_baselines3 import PPO
 from stable_baselines3.common.evaluation import evaluate_policy
 
@@ -27,7 +28,7 @@ from stable_baselines3.common.evaluation import evaluate_policy
 environment_name = EnvironmentName("CartPole-v1")
 model_name = ModelName("ppo", environment_name)
 checkpoint = load_from_hub(
-    repo_id=RepoId("sb3", model_name),
+    repo_id=ModelRepoId("sb3", model_name),
     filename=model_name.filename,
 )
 model = PPO.load(checkpoint)
@@ -63,7 +64,7 @@ import gym
 
 from stable_baselines3 import PPO
 from stable_baselines3.common.env_util import make_vec_env
-from huggingface_sb3 import package_to_hub, EnvironmentName, ModelName, RepoId
+from huggingface_sb3 import package_to_hub, EnvironmentName, ModelName, ModelRepoId
 
 env_name = EnvironmentName("LunarLander-v2")
 model_name = ModelName("ppo", env_name)
@@ -81,12 +82,12 @@ model = PPO('MlpPolicy', env, verbose=1)
 model.learn(total_timesteps=int(5000))
 
 # This method save, evaluate, generate a model card and record a replay video of your agent before pushing the repo to the hub
-package_to_hub(model=model, 
+package_to_hub(model=model,
                model_name=model_name,
                model_architecture="PPO",
                env_id=env_name.env_id,
                eval_env=eval_env,
-               repo_id=RepoId("ThomasSimonini", model_name),
+               repo_id=ModelRepoId("ThomasSimonini", model_name),
                commit_message="Test commit")
 ```
 
@@ -99,7 +100,7 @@ import gym
 
 from stable_baselines3 import PPO
 from stable_baselines3.common.env_util import make_vec_env
-from huggingface_sb3 import push_to_hub, EnvironmentName, ModelName, RepoId
+from huggingface_sb3 import push_to_hub, EnvironmentName, ModelName, ModelRepoId
 
 env_name = EnvironmentName("LunarLander-v2")
 model_name = ModelName("ppo", env_name)
@@ -121,7 +122,7 @@ model.save(model_name)
 ## repo_id = id of the model repository from the Hugging Face Hub (repo_id = {organization}/{repo_name})
 ## filename: the name of the file == "name" inside model.save("ppo-LunarLander-v2")
 push_to_hub(
-    repo_id=RepoId("ThomasSimonini", model_name),
+    repo_id=ModelRepoId("ThomasSimonini", model_name),
     filename=model_name.filename,
     commit_message="Added LunarLander-v2 model trained with PPO",
 )

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ from stable_baselines3.common.env_util import make_vec_env
 from huggingface_sb3 import package_to_hub
 
 # Create the environment
-env_id = 'LunarLander-v2'
+env_id = "LunarLander-v2"
 env = make_vec_env(env_id, n_envs=1)
 
 # Create the evaluation env
 eval_env = make_vec_env(env_id, n_envs=1)
 
 # Instantiate the agent
-model = PPO('MlpPolicy', env, verbose=1)
+model = PPO("MlpPolicy", env, verbose=1)
 
 # Train the agent
 model.learn(total_timesteps=int(5000))
@@ -98,11 +98,11 @@ from stable_baselines3.common.env_util import make_vec_env
 from huggingface_sb3 import push_to_hub
 
 # Create the environment
-env_id = 'LunarLander-v2'
+env_id = "LunarLander-v2"
 env = make_vec_env(env_id, n_envs=1)
 
 # Instantiate the agent
-model = PPO('MlpPolicy', env, verbose=1)
+model = PPO("MlpPolicy", env, verbose=1)
 
 # Train it for 10000 timesteps
 model.learn(total_timesteps=10_000)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ xvfb-run -s "-screen 0 1400x900x24" <your_python_file>
 
 ### Case 5: I want to automate upload/download from the Hub
 If you want to upload or download models for many environments, you might want to 
-automate, this process. 
+automate this process. 
 It makes sense to adhere to a fixed naming scheme for models and repositories.
 You will run into trouble when your environment names contain slashes.
 Therefore, we provide some helper classes:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ from stable_baselines3 import PPO
 from stable_baselines3.common.env_util import make_vec_env
 from huggingface_sb3 import package_to_hub, EnvironmentName, ModelName, RepoId
 
-env_name = EnvironmentName('LunarLander-v2')
+env_name = EnvironmentName("LunarLander-v2")
 model_name = ModelName("ppo", env_name)
 
 # Create the environment

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ from stable_baselines3 import PPO
 from stable_baselines3.common.env_util import make_vec_env
 from huggingface_sb3 import push_to_hub, EnvironmentName, ModelName, RepoId
 
-env_name = EnvironmentName('LunarLander-v2')
+env_name = EnvironmentName("LunarLander-v2")
 model_name = ModelName("ppo", env_name)
 
 # Create the environment

--- a/huggingface_sb3/__init__.py
+++ b/huggingface_sb3/__init__.py
@@ -1,2 +1,3 @@
 from .load_from_hub import load_from_hub
 from .push_to_hub import package_to_hub, push_to_hub
+from .naming_schemes import ModelName, EnvironmentName, RepoId

--- a/huggingface_sb3/__init__.py
+++ b/huggingface_sb3/__init__.py
@@ -1,3 +1,3 @@
 from .load_from_hub import load_from_hub
 from .push_to_hub import package_to_hub, push_to_hub
-from .naming_schemes import ModelName, EnvironmentName, RepoId
+from .naming_schemes import ModelName, EnvironmentName, ModelRepoId

--- a/huggingface_sb3/naming_schemes.py
+++ b/huggingface_sb3/naming_schemes.py
@@ -53,6 +53,11 @@ class ModelName(str):
         return f"{self}.zip"
 
 
-class RepoId(str):
+class ModelRepoId(str):
+    """
+    The name of a repository. Derived from the associated organization and the model
+    name.
+    """
+
     def __new__(cls, org: str, model_name: ModelName):
         return super().__new__(cls, f"{org}/{model_name}")

--- a/huggingface_sb3/naming_schemes.py
+++ b/huggingface_sb3/naming_schemes.py
@@ -1,0 +1,23 @@
+class EnvironmentName(str):
+    def __new__(cls, gym_id: str):
+        n = super().__new__(cls, gym_id.replace("/", "-"))
+        n._gym_id = gym_id
+        return n
+
+    @property
+    def gym_id(self):
+        return self._gym_id
+
+
+class ModelName(str):
+    def __new__(cls, algo_name: str, environment_name: EnvironmentName):
+        return super().__new__(cls, f"{algo_name}-{environment_name}")
+
+    @property
+    def filename(self):
+        return f"{self}.zip"
+
+
+class RepoId(str):
+    def __new__(cls, org: str, model_name: ModelName):
+        return super().__new__(cls, f"{org}/{model_name}")

--- a/huggingface_sb3/naming_schemes.py
+++ b/huggingface_sb3/naming_schemes.py
@@ -1,20 +1,55 @@
+"""
+This module contains a number of string subclasses that help to adhere to a uniform
+naming scheme for models and repository IDs.
+This is especially helpful when pushing or pulling models in an automated fashion e.g.
+when pushing many models from a benchmark such as the rl baselines zoo
+https://github.com/DLR-RM/rl-baselines3-zoo
+"""
+
+# Note: it is best practice to implement __new__ when overriding immutable types
+# read more here:
+# https://docs.python.org/3/reference/datamodel.html#object.__new__
+# https://stackoverflow.com/a/2673863
+
+
 class EnvironmentName(str):
+    """
+    A name of an environment. Slashes are replaced by dashes so the name can be used
+    for construction file paths and URLs without accidentally introducing hierarchy.
+    """
+
     def __new__(cls, gym_id: str):
-        n = super().__new__(cls, gym_id.replace("/", "-"))
-        n._gym_id = gym_id
-        return n
+        normalized_name = super().__new__(cls, gym_id.replace("/", "-"))
+        normalized_name._gym_id = gym_id
+        return normalized_name
 
     @property
     def gym_id(self):
+        """
+        The gym id corresponding to the environment name.
+
+        This is the value to be passed to `gym.make`
+        """
         return self._gym_id
 
 
 class ModelName(str):
+    """
+    A name of a model. Derived from the used algorithm and the environment that has been
+    trained on. Since a normalized environment name is used, it is safe to construct
+    file paths and URLs from the model name.
+    """
+
     def __new__(cls, algo_name: str, environment_name: EnvironmentName):
         return super().__new__(cls, f"{algo_name}-{environment_name}")
 
     @property
     def filename(self):
+        """
+        The filename under which the model is stored
+
+        when saving it using `model.save(model_name)`
+        """
         return f"{self}.zip"
 
 

--- a/huggingface_sb3/naming_schemes.py
+++ b/huggingface_sb3/naming_schemes.py
@@ -1,8 +1,9 @@
 """
-This module contains a number of string subclasses that help to adhere to a uniform
-naming scheme for models and repository IDs.
-This is especially helpful when pushing or pulling models in an automated fashion e.g.
-when pushing many models from a benchmark such as the rl baselines zoo
+This module contains string subclasses that help to adhere to a uniform
+naming scheme for repository ids.
+
+This is especially helpful when pushing or pulling models in an automated fashion, e.g.
+when pushing many models from a benchmark such as the RL Baselines3 Zoo.
 https://github.com/DLR-RM/rl-baselines3-zoo
 """
 

--- a/tests/test_load_from_hub.py
+++ b/tests/test_load_from_hub.py
@@ -23,3 +23,21 @@ def test_load_from_hub_with_naming_scheme_utils():
         model, eval_env, render=False, n_eval_episodes=5, deterministic=True, warn=False
     )
     print(f"mean_reward={mean_reward:.2f} +/- {std_reward}")
+
+
+def test_load_from_hub():
+    # Retrieve the model from the hub
+    ## repo_id = id of the model repository from the Hugging Face Hub (repo_id = {organization}/{repo_name})
+    ## filename = name of the model zip file from the repository
+    checkpoint = load_from_hub(
+        repo_id="sb3/ppo-CartPole-v1",
+        filename="ppo-CartPole-v1.zip",
+    )
+    model = PPO.load(checkpoint)
+
+    # Evaluate the agent and watch it
+    eval_env = gym.make("CartPole-v1")
+    mean_reward, std_reward = evaluate_policy(
+        model, eval_env, render=False, n_eval_episodes=5, deterministic=True, warn=False
+    )
+    print(f"mean_reward={mean_reward:.2f} +/- {std_reward}")

--- a/tests/test_load_from_hub.py
+++ b/tests/test_load_from_hub.py
@@ -1,0 +1,25 @@
+import gym
+
+from huggingface_sb3 import load_from_hub, RepoId, ModelName, EnvironmentName
+from stable_baselines3 import PPO
+from stable_baselines3.common.evaluation import evaluate_policy
+
+
+def test_load_from_hub():
+    # Retrieve the model from the hub
+    ## repo_id = id of the model repository from the Hugging Face Hub (repo_id = {organization}/{repo_name})
+    ## filename = name of the model zip file from the repository
+    environment_name = EnvironmentName("CartPole-v1")
+    model_name = ModelName("ppo", environment_name)
+    checkpoint = load_from_hub(
+        repo_id=RepoId("sb3", model_name),
+        filename=model_name.filename,
+    )
+    model = PPO.load(checkpoint)
+
+    # Evaluate the agent and watch it
+    eval_env = gym.make(environment_name.gym_id)
+    mean_reward, std_reward = evaluate_policy(
+        model, eval_env, render=False, n_eval_episodes=5, deterministic=True, warn=False
+    )
+    print(f"mean_reward={mean_reward:.2f} +/- {std_reward}")

--- a/tests/test_load_from_hub.py
+++ b/tests/test_load_from_hub.py
@@ -5,7 +5,7 @@ from stable_baselines3 import PPO
 from stable_baselines3.common.evaluation import evaluate_policy
 
 
-def test_load_from_hub():
+def test_load_from_hub_with_naming_scheme_utils():
     # Retrieve the model from the hub
     ## repo_id = id of the model repository from the Hugging Face Hub (repo_id = {organization}/{repo_name})
     ## filename = name of the model zip file from the repository

--- a/tests/test_load_from_hub.py
+++ b/tests/test_load_from_hub.py
@@ -1,6 +1,6 @@
 import gym
 
-from huggingface_sb3 import load_from_hub, RepoId, ModelName, EnvironmentName
+from huggingface_sb3 import load_from_hub, ModelRepoId, ModelName, EnvironmentName
 from stable_baselines3 import PPO
 from stable_baselines3.common.evaluation import evaluate_policy
 
@@ -12,7 +12,7 @@ def test_load_from_hub():
     environment_name = EnvironmentName("CartPole-v1")
     model_name = ModelName("ppo", environment_name)
     checkpoint = load_from_hub(
-        repo_id=RepoId("sb3", model_name),
+        repo_id=ModelRepoId("sb3", model_name),
         filename=model_name.filename,
     )
     model = PPO.load(checkpoint)

--- a/tests/test_naming_scheme.py
+++ b/tests/test_naming_scheme.py
@@ -1,0 +1,34 @@
+import pytest
+
+from huggingface_sb3 import EnvironmentName, ModelName, ModelRepoId
+
+
+@pytest.fixture(params=["seals/Walker2d-v0", "LunarLander-v2"])
+def env_id(request) -> str:
+    return request.param
+
+
+@pytest.fixture
+def env_name(env_id) -> EnvironmentName:
+    return EnvironmentName(env_id)
+
+
+@pytest.fixture
+def model_name(env_name: EnvironmentName) -> ModelName:
+    return ModelName("ppo", env_name)
+
+
+@pytest.fixture
+def repo_id(model_name: ModelName) -> ModelRepoId:
+    return ModelRepoId("orga", model_name)
+
+
+def test_that_slashes_are_removed(env_id: str, env_name: EnvironmentName, model_name: ModelName, repo_id: ModelRepoId):
+    assert "/" not in env_name
+    assert "/" not in model_name
+    assert "/" not in model_name.filename
+    assert repo_id.count("/") == 1  # note: repo id has exactly one slash separating org from repo name
+
+
+def test_that_gym_id_is_preserved(env_id: str, env_name: EnvironmentName):
+    assert env_name.gym_id == env_id


### PR DESCRIPTION
There was an issue with environment names, that have a slash in their name (see https://github.com/DLR-RM/rl-baselines3-zoo/pull/257).
Also the naming scheme for models and repository IDs is just based on convention.

This PR implements normalization for environment names (replacing slashes with dashes) and encodes the naming scheme for models and repository IDs in little helper classes. The idea is, that those helper classes can be used by downstream libraries to comply with the naming scheme (such as the rl baselines zoo). If we ever need to change the naming scheme or other cases in which the environment name needs to be normalized come up, then we can implement them here and the downstream libraries immediately profit from that.

I also added a simple smoke test for pulling a model from the hub.