### PR TITLE
Update push_to_hub.py

### DIFF
--- a/huggingface_sb3/push_to_hub.py
+++ b/huggingface_sb3/push_to_hub.py
@@ -101,7 +101,7 @@ def is_atari(env_id: str) -> bool:
     (Taken from RL-Baselines3-zoo)
     :param env_id: name of the environment
     """
-    entry_point = gym.envs.registry.env_specs[env_id].entry_point
+    entry_point = gym.envs.registry[env_id].entry_point
     return "AtariEnv" in str(entry_point)
 
 


### PR DESCRIPTION
Update to gym has altered gym.envs.registry to a dictionary.  The change alters behavior on the initial huggingface.co Unit1 tutorial if not using Google CoLab.

Reproduce using WSL windows 10 ubuntu 
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.1 LTS
Release:        22.04

To Reproduce:
Follow tutorial on Unit1 as defined...


>>> package_to_hub(model=model, model_name=model_name,model_architecture=model_architecture,env_id=env_id,eval_env=eval_env,repo_id=repo_id,commit_message=commit_message)
ℹ This function will save, evaluate, generate a video of your agent, create a model card and push everything to the hub. It might take up to 1min. This is a work in progress: if you encounter a bug, please open an issue. Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/theiss/.local/lib/python3.10/site-packages/huggingface_sb3/push_to_hub.py", line 364, in package_to_hub
    is_deterministic = not is_atari(env_id)
  File "/home/theiss/.local/lib/python3.10/site-packages/huggingface_sb3/push_to_hub.py", line 104, in is_atari
    entry_point = gym.envs.registry[env_id].entry_point
AttributeError: 'dict' object has no attribute 'env_specs'
 



Similar to issue mentioned: 
File "/home/anavani/anaconda3/envs/rad/lib/python3.7/site-packages/dmc2gym/__init__.py", line 28, in make
   if not env_id in gym.envs.registry.env_specs:
AttributeError: 'dict' object has no attribute 'env_specs'

https://github.com/openai/gym/issues/3097