### PR TITLE
refactor: remove os.system call :recycle:

### DIFF
--- a/huggingface_sb3/push_to_hub.py
+++ b/huggingface_sb3/push_to_hub.py
@@ -1,7 +1,10 @@
 import datetime
 import json
 import os
+import shlex
 import shutil
+import subprocess
+import sys
 import tempfile
 import zipfile
 from pathlib import Path
@@ -153,12 +156,15 @@ def _generate_replay(
             # Convert the video with x264 codec
             inp = env.video_recorder.path
             out = os.path.join(local_path, "replay.mp4")
-            os.system(f"ffmpeg -y -i {inp} -vcodec h264 {out}".format(inp, out))
+            cmd = f"ffmpeg -y -i {inp} -vcodec h264 {out}".format(inp, out)
+            completed_process = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE,
+                                               stderr=subprocess.STDOUT, check=True)
+            print(completed_process.stdout.decode(), file=sys.stderr)
 
         except KeyboardInterrupt:
             pass
-        except Exception as e:
-            msg.fail(str(e))
+        except subprocess.CalledProcessError as e:
+            msg.fail(e.stderr.decode())
             # Add a message for video
             msg.fail(
                 "We are unable to generate a replay of your agent, "

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras["quality"] = [
 
 setup(
     name='huggingface_sb3',
-    version='2.2.4',
+    version='2.2.5',
     packages=['huggingface_sb3'],
     url='https://github.com/huggingface/huggingface_sb3',
     license='Apache',


### PR DESCRIPTION
According to [Python docs](https://docs.python.org/3/library/os.html#os.system), `os.system` should be replaced with `subprocess` module, in particular [`subprocess.run`](https://docs.python.org/3/library/subprocess.html#subprocess.run).

Instead of a string, `subprocess.run` expects a list of arguments, so that 

```python
f'ffmpeg -y -i {inp} -vcodec h264 {out}'
```

becomes

```python
['ffmpeg', '-y', f'-y {inp}', '-vcodec h264', f'"{out}"']
```

`shlex.split()` takes care of automatically breaking a shell command into a sequence of arguments, so that we don't have to determine how to correctly tokenize the args manually.

Lastly, the output is printed to the stderr only to be as close as possible to the current formatting, and the generic `Exception` is replaced by `CalledProcessError`, which is thrown when the command launched by `subprocess.run` fails with a non-zero return code. This check is performed thanks to the parameter `check=True`.