### PR TITLE
Env name normalization update

### DIFF
--- a/huggingface_sb3/naming_schemes.py
+++ b/huggingface_sb3/naming_schemes.py
@@ -20,7 +20,17 @@ class EnvironmentName(str):
     """
 
     def __new__(cls, gym_id: str):
-        normalized_name = super().__new__(cls, gym_id.replace("/", "-"))
+        normalized_str = gym_id.replace("/", "-")
+        if ":" in normalized_str:
+            split_by_colon = normalized_str.split(":")
+            if len(split_by_colon) == 2:
+                # split by colon and take the first part
+                normalized_str = split_by_colon[1]
+            else:
+                raise ValueError(
+                    f"Environment name {gym_id} contains more than one colon!"
+                )
+        normalized_name = super().__new__(cls, normalized_str)
         normalized_name._gym_id = gym_id
         return normalized_name
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,9 @@ install_requires = [
     "pyyaml~=6.0",
     "wasabi",
     "numpy",
-    "cloudpickle>=1.6"
+    "cloudpickle>=1.6",
+    "gym~=0.21",
+    "stable-baselines3~=1.7",
 ]
 
 extras = {}

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ install_requires = [
     "wasabi",
     "numpy",
     "cloudpickle>=1.6",
-    "gym~=0.21",
-    "stable-baselines3~=1.7",
 ]
 
 extras = {}

--- a/tests/test_naming_scheme.py
+++ b/tests/test_naming_scheme.py
@@ -3,7 +3,7 @@ import pytest
 from huggingface_sb3 import EnvironmentName, ModelName, ModelRepoId
 
 
-@pytest.fixture(params=["seals/Walker2d-v0", "LunarLander-v2"])
+@pytest.fixture(params=["seals/Walker2d-v0", "LunarLander-v2", "seals:seals/Walker2d-v0"])
 def env_id(request) -> str:
     return request.param
 
@@ -23,11 +23,23 @@ def repo_id(model_name: ModelName) -> ModelRepoId:
     return ModelRepoId("orga", model_name)
 
 
-def test_that_slashes_are_removed(env_id: str, env_name: EnvironmentName, model_name: ModelName, repo_id: ModelRepoId):
+def test_that_slashes_are_removed(env_name: EnvironmentName, model_name: ModelName, repo_id: ModelRepoId):
     assert "/" not in env_name
     assert "/" not in model_name
     assert "/" not in model_name.filename
     assert repo_id.count("/") == 1  # note: repo id has exactly one slash separating org from repo name
+
+
+def test_that_colon_is_removed(env_name: EnvironmentName, model_name: ModelName, repo_id: ModelRepoId):
+    assert ":" not in env_name
+    assert ":" not in model_name
+    assert ":" not in model_name.filename
+    assert ":" not in repo_id
+
+
+def test_that_package_before_colon_is_removed():
+    env_name = EnvironmentName("seals:seals/Walker2d-v0")
+    assert env_name == "seals-Walker2d-v0"
 
 
 def test_that_gym_id_is_preserved(env_id: str, env_name: EnvironmentName):

--- a/tests/test_naming_scheme.py
+++ b/tests/test_naming_scheme.py
@@ -42,5 +42,10 @@ def test_that_package_before_colon_is_removed():
     assert env_name == "seals-Walker2d-v0"
 
 
+def test_that_double_colon_is_rejected():
+    with pytest.raises(ValueError):
+        EnvironmentName("seals:seals:Walker2d-v0")
+
+
 def test_that_gym_id_is_preserved(env_id: str, env_name: EnvironmentName):
     assert env_name.gym_id == env_id


### PR DESCRIPTION
Since `gym>=0.21.0` and with `gymnasium`, there is the possibility to add a `package:` prefix to the Gym ID to ensure that the given package is imported before creating the environment.

More details here: https://github.com/HumanCompatibleAI/imitation/pull/743#issuecomment-1620179983

This PR ensures that this package prefix is being removed from normalized environment names.
It also adds some missing dependencies.