### PR TITLE
Gymnasium support, with shimmy 

### DIFF
--- a/huggingface_sb3/push_to_hub.py
+++ b/huggingface_sb3/push_to_hub.py
@@ -7,7 +7,7 @@ import zipfile
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union
 
-import gym
+import gymnasium as gym
 import numpy as np
 import stable_baselines3
 from huggingface_hub import HfApi, upload_folder

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ install_requires = [
     "pyyaml~=6.0",
     "wasabi",
     "numpy",
-    "cloudpickle>=1.6"
+    "cloudpickle>=1.6",
+    "shimmy>=0.2.1"
 ]
 
 extras = {}

--- a/tests/test_load_from_hub.py
+++ b/tests/test_load_from_hub.py
@@ -1,4 +1,4 @@
-import gym
+import gymnasium as gym
 
 from huggingface_sb3 import load_from_hub, ModelRepoId, ModelName, EnvironmentName
 from stable_baselines3 import PPO


### PR DESCRIPTION
- Replacing gym dependency with gymnasium
- added `shimmy` dependency, needed by `sb3` 

relevant to #30 

IMPORTANT: 
some tests do not yet pass, due to loading policies from the hub that require `gym` 