### PR TITLE
Gymnasium Support (v2.3)

### DIFF
--- a/huggingface_sb3/push_to_hub.py
+++ b/huggingface_sb3/push_to_hub.py
@@ -7,7 +7,6 @@ import zipfile
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union
 
-import gym as gym26
 import gymnasium as gym
 import numpy as np
 import stable_baselines3
@@ -99,6 +98,7 @@ def entry_point(env_id: str) -> str:
     try:
         return str(gym.envs.registry[env_id].entry_point)
     except KeyError:
+        import gym as gym26
         return str(gym26.envs.registry[env_id].entry_point)
 
 def is_atari(env_id: str) -> bool:

--- a/huggingface_sb3/push_to_hub.py
+++ b/huggingface_sb3/push_to_hub.py
@@ -7,7 +7,8 @@ import zipfile
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union
 
-import gym
+import gym as gym26
+import gymnasium as gym
 import numpy as np
 import stable_baselines3
 from huggingface_hub import HfApi, upload_folder
@@ -94,6 +95,11 @@ def _evaluate_agent(
 
     return mean_reward, std_reward
 
+def entry_point(env_id: str) -> str:
+    try:
+        return str(gym.envs.registry[env_id].entry_point)
+    except KeyError:
+        return str(gym26.envs.registry[env_id].entry_point)
 
 def is_atari(env_id: str) -> bool:
     """
@@ -101,8 +107,7 @@ def is_atari(env_id: str) -> bool:
     (Taken from RL-Baselines3-zoo)
     :param env_id: name of the environment
     """
-    entry_point = gym.envs.registry.env_specs[env_id].entry_point
-    return "AtariEnv" in str(entry_point)
+    return "AtariEnv" in entry_point(env_id)
 
 
 def _generate_replay(


### PR DESCRIPTION
Due to SB3 v2.0 that switched to Gymnasium as primary backend. We updated for this v2.3

There was a mistake with v2.2.5, it was not gymnasium compatible.

This new version deletes gymnasium branch and close its PR
This replies the question #30

@araffin is it possible for the next RL-Zoo version in the todo to set in requirements `huggingface_sb3>=2.3` ? 

@ernestum we're going to merge your PR after the small requirements.txt changes.