### PR TITLE
Revert v2.5.5 for v2.3.1 Gym compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ A library to load and upload Stable-baselines3 models from the Hub.
 ```
 pip install huggingface-sb3
 ```
+### IF YOU USE GYMNASIUM ENVIRONMENTS USE THIS INSTALL
+
+```
+pip install git+https://github.com/huggingface/huggingface_sb3@gymnasium
+```
 
 ## Examples
 We wrote a tutorial on how to use 🤗 Hub and Stable-Baselines3 [here](https://colab.research.google.com/github/huggingface/deep-rl-class/blob/master/notebooks/unit1/unit1.ipynb)


### PR DESCRIPTION
Context: We launched a major release v2.3 Gymnasium compatible.

But we should instead let v2.x to be Gym compatible and v3. to be Gymnasium compatible. 

See: #37 

So we're:
-  Doing a v2.3.1 release with the state of v2.2.5
- Doing a v3.0 release with the state of v2.3.0