### PR TITLE
Fix issue when generating video in package_to_hub in push_to_hub.py

### DIFF
--- a/huggingface_sb3/push_to_hub.py
+++ b/huggingface_sb3/push_to_hub.py
@@ -152,7 +152,7 @@ def _generate_replay(
             env.close()
 
             # Convert the video with x264 codec
-            inp = env.video_recorder.path
+            inp = env.video_path
             out = os.path.join(local_path, "replay.mp4")
             os.system(f"ffmpeg -y -i {inp} -vcodec h264 {out}".format(inp, out))
 


### PR DESCRIPTION
Fixes issue #45 and #46

When trying to package a model, the following error is displayed:

✘ 'DummyVecEnv' object has no attribute 'video_recorder'
✘ We are unable to generate a replay of your agent, the package_to_hub
process continues

This PR fixes the issues by using the env.video_path attribute instead of the env.video_recorder.path attrribute which does not work